### PR TITLE
add remote llm fallback

### DIFF
--- a/background.js
+++ b/background.js
@@ -6,3 +6,27 @@ chrome.runtime.onInstalled.addListener(() => {
         }
     });
 });
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+    if (msg?.type === "AF_QUERY_LLM") {
+        (async () => {
+            try {
+                const { af_llmBaseUrl, af_llmApiKey } = await chrome.storage.local.get(["af_llmBaseUrl", "af_llmApiKey"]);
+                if (!af_llmBaseUrl) { sendResponse({}); return; }
+                const headers = { "Content-Type": "application/json" };
+                if (af_llmApiKey) headers["Authorization"] = `Bearer ${af_llmApiKey}`;
+                const resp = await fetch(af_llmBaseUrl, {
+                    method: "POST",
+                    headers,
+                    body: JSON.stringify({ prompt: msg.prompt })
+                });
+                const data = await resp.json();
+                sendResponse({ answer: data.answer || data.result || data.choices?.[0]?.text || "" });
+            } catch (e) {
+                console.warn("[AutoFill] LLM fetch failed:", e?.message);
+                sendResponse({});
+            }
+        })();
+        return true;
+    }
+});

--- a/llm_proxy.py
+++ b/llm_proxy.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Simple Flask-based proxy for AutoFill's remote LLM feature.
+
+Run:
+    AF_LLM_URL=https://example.com/chat AF_LLM_API_KEY=sk-... python llm_proxy.py
+
+Set the extension's LLM base URL to http://localhost:5000/query and leave the API key blank.
+This server forwards prompts to the real LLM and returns the answer.
+"""
+import os
+from flask import Flask, request, jsonify
+import requests
+
+app = Flask(__name__)
+
+LLM_URL = os.environ.get("AF_LLM_URL", "")
+API_KEY = os.environ.get("AF_LLM_API_KEY", "")
+
+@app.post("/query")
+def query():
+    data = request.get_json(force=True)
+    prompt = data.get("prompt", "")
+    headers = {"Content-Type": "application/json"}
+    if API_KEY:
+        headers["Authorization"] = f"Bearer {API_KEY}"
+    resp = requests.post(LLM_URL, headers=headers, json={"prompt": prompt})
+    try:
+        payload = resp.json()
+    except ValueError:
+        return jsonify({"answer": ""}), 500
+    answer = (
+        payload.get("answer")
+        or payload.get("result")
+        or (payload.get("choices") or [{}])[0].get("text")
+        or ""
+    )
+    return jsonify({"answer": answer})
+
+if __name__ == "__main__":
+    app.run(port=5000)

--- a/options.html
+++ b/options.html
@@ -39,6 +39,13 @@
     <label>Summary / Bio</label><textarea id="summary" rows="3"></textarea>
 </div>
 
+<h2>Remote LLM</h2>
+<p>Configure a cloud LLM to answer unmatched fields.</p>
+<div class="grid">
+    <label>Base URL</label><input id="llmBaseUrl" />
+    <label>API Key (optional)</label><input id="llmApiKey" type="password" />
+</div>
+
 <h2>Encryption</h2>
 <p>Encrypt profile at rest with a passphrase. You’ll unlock it from the popup when filling forms.</p>
 <div class="grid">

--- a/options.js
+++ b/options.js
@@ -15,7 +15,7 @@ async function getSessionPass() {
 }
 
 async function load() {
-    const local = await chrome.storage.local.get(["af_profile", "af_profile_enc"]);
+    const local = await chrome.storage.local.get(["af_profile", "af_profile_enc", "af_llmBaseUrl", "af_llmApiKey"]);
     const encBundle = local.af_profile_enc;
     const sessionPass = await getSessionPass();
 
@@ -35,6 +35,8 @@ async function load() {
     }
 
     fields.forEach(k => { const el = $(k); if (el && profile[k] !== undefined) el.value = profile[k]; });
+    $("llmBaseUrl").value = local.af_llmBaseUrl || "";
+    $("llmApiKey").value = local.af_llmApiKey || "";
 }
 
 async function save() {
@@ -44,6 +46,8 @@ async function save() {
 
     const profile = {};
     fields.forEach(k => profile[k] = $(k).value.trim());
+    const llmBaseUrl = $("llmBaseUrl").value.trim();
+    const llmApiKey = $("llmApiKey").value.trim();
 
     if (encEnabled) {
         if (!pass || pass !== pass2) { alert("Passphrases must be non-empty and match."); return; }
@@ -58,12 +62,13 @@ async function save() {
         await chrome.storage.local.remove("af_profile_enc");
         alert("Saved (plaintext).");
     }
+    await chrome.storage.local.set({ af_llmBaseUrl: llmBaseUrl, af_llmApiKey: llmApiKey });
     await load();
 }
 
 async function reset() {
     if (!confirm("Clear all stored profile data (both plaintext and encrypted)?")) return;
-    await chrome.storage.local.remove(["af_profile", "af_profile_enc"]);
+    await chrome.storage.local.remove(["af_profile", "af_profile_enc", "af_llmBaseUrl", "af_llmApiKey"]);
     await load();
 }
 


### PR DESCRIPTION
## Summary
- allow remote LLM queries without an API key so a local Python proxy can be used
- add example `llm_proxy.py` Flask server to forward prompts to a cloud LLM
- label the API key field as optional in the options page
