### PR TITLE
Enable CORS for local LLM server

### DIFF
--- a/localLLM.py
+++ b/localLLM.py
@@ -18,6 +18,7 @@ curl -X POST http://localhost:11434/api/generate \
 from __future__ import annotations
 
 from flask import Flask, jsonify, request
+from flask_cors import CORS
 from transformers import AutoModelForCausalLM, AutoTokenizer
 import torch
 
@@ -29,6 +30,9 @@ model = AutoModelForCausalLM.from_pretrained(MODEL_NAME)
 model.eval()
 
 app = Flask(__name__)
+# Replace "*" with specific domains like "https://apply.etc.cmu.edu" or
+# "chrome-extension://<extension-id>" to restrict access.
+CORS(app, resources={r"/api/*": {"origins": "*"}})
 
 @app.post("/api/generate")
 def generate():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 transformers
 torch
 flask
+flask-cors
 langchain
 langchain-huggingface


### PR DESCRIPTION
## Summary
- allow cross-origin requests to `/api/*` by enabling Flask-CORS
- document how to tighten allowed origins for specific domains
- add Flask-CORS to requirements

## Testing
- `pip install flask-cors` *(fails: Could not connect to proxy)*
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `python localLLM.py` *(fails: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68b43b2784688332ba60bddef841a393